### PR TITLE
[bugfix] Fix MacOS builds

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,4 +1,0 @@
-[build]
-rustflags = ["-C", "target-feature=+crt-static"]
-target = "x86_64-unknown-linux-gnu"
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,18 +29,18 @@ jobs:
       with:
         args: cargo build --target x86_64-unknown-linux-musl --release
 
-#    - name: Upload macOS x86 binary to release
-#      uses: Spikatrix/upload-release-action@b713c4b73f0a8ddda515820c124efc6538685492
-#      with:
-#        repo_token: ${{ secrets.GITHUB_TOKEN }}
-#        file: target/x86_64-apple-darwin/release/${{ env.BINARY_NAME }}
-#        asset_name: ${{ env.BINARY_NAME }}-macos-x86
-#        target_commit: ${{ github.sha }}
-#        tag: v${{ env.RELEASE_VERSION }}
-#        release_name: v${{ env.RELEASE_VERSION }}
-#        prerelease: false
-#        overwrite: true
-#        body: ${{ env.BINARY_NAME }} release
+    # - name: Upload macOS x86 binary to release
+    #   uses: Spikatrix/upload-release-action@b713c4b73f0a8ddda515820c124efc6538685492
+    #   with:
+    #     repo_token: ${{ secrets.GITHUB_TOKEN }}
+    #     file: target/x86_64-apple-darwin/release/${{ env.BINARY_NAME }}
+    #     asset_name: ${{ env.BINARY_NAME }}-macos-x86
+    #     target_commit: ${{ github.sha }}
+    #     tag: v${{ env.RELEASE_VERSION }}
+    #     release_name: v${{ env.RELEASE_VERSION }}
+    #     prerelease: false
+    #     overwrite: true
+    #     body: ${{ env.BINARY_NAME }} release
 
     - name: Upload linux binary to release
       uses: Spikatrix/upload-release-action@b713c4b73f0a8ddda515820c124efc6538685492

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --target x86_64-unknown-linux-gnu --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --target x86_64-unknown-linux-gnu --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "echtvar"
 version = "0.1.4"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,9 +15,6 @@ path = "src/main.rs"
 
 
 [dependencies]
-
-flate2 = { version = "1.0", features = ["zlib-ng-compat"]}
-
 rust-htslib = { version = "0.38.2", features = ["libdeflate", "static"] }
 #bitpacking = "0.8.4"
 stream-vbyte = {version = "0.4.0", features=["x86_ssse3", "x86_sse41"]}
@@ -25,7 +22,7 @@ clap = {version = "~2.27.0", features=["suggestions"] }
 c2rust-bitfields = "0.3.0"
 libc = "*"
 # TODO: try deflate-miniz, deflate-zlib, deflate
-zip = { version = "0.5", default-features = false, features=["deflate"] }
+zip = { version = "0.6", default-features = false, features=["deflate"] }
 byteorder = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -38,4 +35,3 @@ bincode = { version = "1.3.3" }
 [profile.release]
 lto = "fat"
 codegen-units = 1
-target = "x86_64"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,4 @@
 [toolchain]
+# Nightly needed for portable simd feature
 channel = "nightly"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
The issue was twofold
1) The hardcoded targets could be overridden by explicitly passing in the darwin target, but I don think they are actually needed anyways?
2) The `flate2` dependency was causing encode to segfault. I'm not 100% sure why. I don't think the flate2 dep was needed or doing anything to start with, but something deep in the internals was getting messed up by it being there. `zip` uses the rust `flate2` backend when the `deflate` feature is specified. I think having the `zlib-ng-compat` backend around at compile time was causing issues. I'm not sure why the same issues don't show up on ubuntu. It's probably worth making sure that the ubuntu version wasn't magically using the `zlib-ng-compat` backend inside of `zip` or this would be a performance regression.

Long term it may be worth trying to add `zlib-ng-compat` support to `zip`, although it looks like they have a big re-write under way at the moment. 

I did not try to fix the github builds as I wasn't sure exactly how those were wired up right now anyways.

@brentp - if this gets merged, would it be possible to get a new release with the fix from yesterday and this fix? 
