### PR TITLE
Fix vcf header in cadd2vcf.py

### DIFF
--- a/examples/cadd/cadd2vcf.py
+++ b/examples/cadd/cadd2vcf.py
@@ -12,7 +12,7 @@ def main(precision, path):
 ##INFO=<ID=phred,Number=1,Type=Float,Description="phred-scaled cadd score">
 {contigs}
 ##CADDCOMMENT=<ID=comment,comment="{comment}">
-#CHROM  POS ID  REF ALT QUAL    FILTER  INFO"""
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO"""
 
     contigs = []
     for i in range(1, 23):


### PR DESCRIPTION
Changed spaces (possibly the result of copying over a header `cat`ted to terminal) to tab literals (`\t`). This makes bcftools much happier.