### PR TITLE
🐛 report BCF2 missing floats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ fasteval = { version = "0.2.4", features = ["unsafe-vars"] }
 bincode = { version = "1.3.3" }
 json5 = "0.4.1"
 
+ieee754 = "0.2"
+
 [profile.release]
 lto = "fat"
 codegen-units = 1


### PR DESCRIPTION
Hi Brent,

This PR gives floats dot notation when you set their `missing_value` to `2139095041`.

Going off discussion in #28 , I tested the BCF2 value of `0x7F800001/2139095041` as the `missing_value` to no avail. I was unable to find any `i32` value that could generate the necessary `f32` value. 

This solution mirrors the methodology used in rust-htslib for missing floats: https://github.com/rust-bio/rust-htslib/blob/3008a131f241b423d041c756fc96410f6412e3d8/src/bcf/record.rs#L33.