### PR TITLE
🔨 Scrape Number and Specify Description

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echtvar"
-version = "0.2.0-rc"
+version = "0.1.9"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echtvar"
-version = "0.1.9"
+version = "0.2.0-rc"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/commands/annotate_cmd.rs
+++ b/src/commands/annotate_cmd.rs
@@ -34,6 +34,7 @@ pub fn annotate_main(
             e
         })
         .collect();
+    EchtVars::add_cmd_header(&mut header, &ipath, &opath, &include_expr, epaths);
 
     let parser = fasteval::Parser::new();
     let mut slab = fasteval::Slab::new();

--- a/src/commands/encoder_cmd.rs
+++ b/src/commands/encoder_cmd.rs
@@ -216,6 +216,14 @@ pub fn encoder_main(vpaths: Vec<&str>, opath: &str, jpath: &str) {
                 "[echtvar] unsupported field type: {:?} for field {}",
                 tt, f.field
             ),
+        };
+        match _tl {
+            TagLength::Fixed(value) => f.number = format!("Number={}", value),
+            TagLength::AltAlleles => f.number = "Number=A".to_string(),
+            TagLength::Alleles => f.number = "Number=R".to_string(),
+            TagLength::Genotypes => f.number = "Number=G".to_string(),
+            TagLength::Variable => f.number = "Number=.".to_string(),
+            _ => println!("Kill me"),
         }
     }
 

--- a/src/commands/encoder_cmd.rs
+++ b/src/commands/encoder_cmd.rs
@@ -218,12 +218,11 @@ pub fn encoder_main(vpaths: Vec<&str>, opath: &str, jpath: &str) {
             ),
         };
         match _tl {
-            TagLength::Fixed(value) => f.number = format!("Number={}", value),
-            TagLength::AltAlleles => f.number = "Number=A".to_string(),
-            TagLength::Alleles => f.number = "Number=R".to_string(),
-            TagLength::Genotypes => f.number = "Number=G".to_string(),
-            TagLength::Variable => f.number = "Number=.".to_string(),
-            _ => println!("Kill me"),
+            TagLength::Fixed(value) => f.number = value.to_string(),
+            TagLength::AltAlleles => f.number = "A".to_string(),
+            TagLength::Alleles => f.number = "R".to_string(),
+            TagLength::Genotypes => f.number = "G".to_string(),
+            TagLength::Variable => f.number = ".".to_string(),
         }
     }
 

--- a/src/lib/echtvar.rs
+++ b/src/lib/echtvar.rs
@@ -179,7 +179,11 @@ impl EchtVars {
                 format!(
                     "##INFO=<ID={},Number={},Type={},Description=\"{}\">",
                     e.alias,
-                    e.number,
+                    if vec!["A", "R", "G"].iter().any(|n| n == &e.number) {
+                        "1"
+                    } else {
+                        &e.number
+                    },
                     if e.ftype == fields::FieldType::Integer {
                         "Integer"
                     } else if e.ftype == fields::FieldType::Categorical {
@@ -187,10 +191,10 @@ impl EchtVars {
                     } else {
                         "Float"
                     },
-                    if &e.description.to_string() == "added by echtvar"{
+                    if &e.description.to_string() == "added by echtvar" {
                         format!("added by echtvar from {}", path)
                     } else {
-                        format!("added by echtvar {}", e.description.to_string())
+                        e.description.to_string()
                     }
                 )
                 .as_bytes(),
@@ -200,11 +204,11 @@ impl EchtVars {
     pub fn add_cmd_header(header: &mut bcf::header::Header, vpath: &str, opath: &str, include_expr: &Option<&str>, epaths: Vec<&str>) {
         header.push_record(
             format!(
-                "##echtvar_anno_Command=anno -i {:?} {} {} -e {:?}",
+                "##echtvar_annoCommand=anno -i {:?} {} {} -e {:?}",
                 include_expr,
                 vpath,
                 opath,
-                epaths
+                epaths.join(" -e ")
             ).as_bytes(),
         );
     }

--- a/src/lib/echtvar.rs
+++ b/src/lib/echtvar.rs
@@ -197,6 +197,17 @@ impl EchtVars {
             );
         }
     }
+    pub fn add_cmd_header(header: &mut bcf::header::Header, vpath: &str, opath: &str, include_expr: &Option<&str>, epaths: Vec<&str>) {
+        header.push_record(
+            format!(
+                "##echtvar_anno_Command=anno -i {:?} {} {} -e {:?}",
+                include_expr,
+                vpath,
+                opath,
+                epaths
+            ).as_bytes(),
+        );
+    }
 
     #[inline(always)]
     pub fn set_position(

--- a/src/lib/echtvar.rs
+++ b/src/lib/echtvar.rs
@@ -187,7 +187,11 @@ impl EchtVars {
                     } else {
                         "Float"
                     },
-                    e.description
+                    if &e.description.to_string() == "added by echtvar"{
+                        format!("added by echtvar from {}", path)
+                    } else {
+                        e.description.to_string()
+                    }
                 )
                 .as_bytes(),
             );

--- a/src/lib/echtvar.rs
+++ b/src/lib/echtvar.rs
@@ -194,7 +194,7 @@ impl EchtVars {
                     if &e.description.to_string() == "added by echtvar" {
                         format!("added by echtvar from {}", path)
                     } else {
-                        e.description.to_string()
+                        format!("added by echtvar {}", e.description.to_string())
                     }
                 )
                 .as_bytes(),

--- a/src/lib/echtvar.rs
+++ b/src/lib/echtvar.rs
@@ -190,7 +190,7 @@ impl EchtVars {
                     if &e.description.to_string() == "added by echtvar"{
                         format!("added by echtvar from {}", path)
                     } else {
-                        e.description.to_string()
+                        format!("added by echtvar {}", e.description.to_string())
                     }
                 )
                 .as_bytes(),

--- a/src/lib/echtvar.rs
+++ b/src/lib/echtvar.rs
@@ -177,8 +177,9 @@ impl EchtVars {
         for e in &self.fields {
             header.push_record(
                 format!(
-                    "##INFO=<ID={},Number=1,Type={},Description=\"{}\">",
+                    "##INFO=<ID={},{},Type={},Description=\"{}\">",
                     e.alias,
+                    e.number,
                     if e.ftype == fields::FieldType::Integer {
                         "Integer"
                     } else if e.ftype == fields::FieldType::Categorical {
@@ -186,7 +187,7 @@ impl EchtVars {
                     } else {
                         "Float"
                     },
-                    format!("added by echtvar from {}", path)
+                    e.description
                 )
                 .as_bytes(),
             );

--- a/src/lib/echtvar.rs
+++ b/src/lib/echtvar.rs
@@ -177,7 +177,7 @@ impl EchtVars {
         for e in &self.fields {
             header.push_record(
                 format!(
-                    "##INFO=<ID={},{},Type={},Description=\"{}\">",
+                    "##INFO=<ID={},Number={},Type={},Description=\"{}\">",
                     e.alias,
                     e.number,
                     if e.ftype == fields::FieldType::Integer {

--- a/src/lib/fields.rs
+++ b/src/lib/fields.rs
@@ -61,7 +61,7 @@ impl Default for Field {
             zigzag: false,
             multiplier: 1,
             ftype: FieldType::Integer,
-            number: "Number=.".to_string(),
+            number: ".".to_string(),
             values_i: usize::MAX,
         }
     }

--- a/src/lib/fields.rs
+++ b/src/lib/fields.rs
@@ -15,6 +15,8 @@ pub struct Field {
     pub missing_value: i32,
     #[serde(default = "default_missing_string")]
     pub missing_string: std::string::String,
+    #[serde(default = "default_description_string")]
+    pub description: std::string::String,
 
     #[serde(default)]
     pub zigzag: bool,
@@ -23,6 +25,11 @@ pub struct Field {
     pub multiplier: u32,
     #[serde(default)]
     pub ftype: FieldType,
+    #[serde(default)]
+    pub number: std::string::String,
+
+
+
     #[serde(default = "default_values_i", skip_serializing)]
     pub values_i: usize,
 }
@@ -32,6 +39,9 @@ fn default_missing_value() -> i32 {
 }
 fn default_missing_string() -> std::string::String {
     "MISSING".to_string()
+}
+fn default_description_string() -> std::string::String {
+    "added by echtvar".to_string()
 }
 fn default_multiplier() -> u32 {
     1
@@ -47,9 +57,11 @@ impl Default for Field {
             alias: "name".to_string(),
             missing_value: -1,
             missing_string: "MISSING".to_string(),
+            description: "added by echtvar".to_string(),
             zigzag: false,
             multiplier: 1,
             ftype: FieldType::Integer,
+            number: "Number=.".to_string(),
             values_i: usize::MAX,
         }
     }

--- a/tests/big.sh
+++ b/tests/big.sh
@@ -17,7 +17,9 @@ for mod in 2 3 4 5; do
 	# check that some variants remain unannotated
 	python3 check.py anno.vcf.gz $mod
 	# check custom INFO Description used from config
-	python3 check-string-for-issue33.py anno.vcf.gz aval "added by echtvar TEST description field"
+	python3 check-string-for-issue33.py anno.vcf.gz aval 1 "TEST description field"
+	# check A/R/G converted to 1 for number
+	python3 check-string-for-issue33.py anno.vcf.gz external_AC 1 "Theoretical AC from another source"
 
 
         if [[ "mod" -ne "1" ]]; then
@@ -27,7 +29,9 @@ for mod in 2 3 4 5; do
 	    $echtvar anno generated-all.vcf -e test.echtvar0 -e test.echtvar1 anno.vcf.gz
   	    python3 check.py anno.vcf.gz 1
 		# check default Description used
-		python3 check-string-for-issue33.py anno.vcf.gz aval1 "added by echtvar from test.echtvar1"
+		python3 check-string-for-issue33.py anno.vcf.gz aval1 1 "added by echtvar from test.echtvar1"
+		# check value . is left alone
+		python3 check-string-for-issue33.py anno.vcf.gz external_str . "added by echtvar from test.echtvar1"
         fi
 
 

--- a/tests/big.sh
+++ b/tests/big.sh
@@ -17,9 +17,9 @@ for mod in 2 3 4 5; do
 	# check that some variants remain unannotated
 	python3 check.py anno.vcf.gz $mod
 	# check custom INFO Description used from config
-	python3 check-string-for-issue33.py anno.vcf.gz aval 1 "TEST description field"
+	python3 check-string-for-issue33.py anno.vcf.gz aval 1 "added by echtvar TEST description field"
 	# check A/R/G converted to 1 for number
-	python3 check-string-for-issue33.py anno.vcf.gz external_AC 1 "Theoretical AC from another source"
+	python3 check-string-for-issue33.py anno.vcf.gz external_AC 1 "added by echtvar Theoretical AC from another source"
 
 
         if [[ "mod" -ne "1" ]]; then

--- a/tests/big.sh
+++ b/tests/big.sh
@@ -16,6 +16,8 @@ for mod in 2 3 4 5; do
 
 	# check that some variants remain unannotated
 	python3 check.py anno.vcf.gz $mod
+	# check custom INFO Description used from config
+	python3 check-string-for-issue33.py anno.vcf.gz aval "added by echtvar TEST description field"
 
 
         if [[ "mod" -ne "1" ]]; then
@@ -24,6 +26,8 @@ for mod in 2 3 4 5; do
 	    $echtvar encode test.echtvar1 test1.hjson generated-subset1.vcf
 	    $echtvar anno generated-all.vcf -e test.echtvar0 -e test.echtvar1 anno.vcf.gz
   	    python3 check.py anno.vcf.gz 1
+		# check default Description used
+		python3 check-string-for-issue33.py anno.vcf.gz aval1 "added by echtvar from test.echtvar1"
         fi
 
 
@@ -61,7 +65,7 @@ for mod in 2 3 4 5; do
 
 
 done
-# rm generated-all.vcf generated-subset0.vcf anno.vcf.gz test.echtvar0 test.echtvar1
+rm generated-all.vcf generated-subset0.vcf anno.vcf.gz test.echtvar0 test.echtvar1
 bash string.sh
 echo "SUCCESS"
 

--- a/tests/big.sh
+++ b/tests/big.sh
@@ -61,7 +61,7 @@ for mod in 2 3 4 5; do
 
 
 done
-rm generated-all.vcf generated-subset0.vcf anno.vcf.gz test.echtvar0 test.echtvar1
+# rm generated-all.vcf generated-subset0.vcf anno.vcf.gz test.echtvar0 test.echtvar1
 bash string.sh
 echo "SUCCESS"
 

--- a/tests/check-string-for-issue33.py
+++ b/tests/check-string-for-issue33.py
@@ -6,14 +6,17 @@ import gzip
 
 fpath = sys.argv[1]
 field = sys.argv[2]
-desc = sys.argv[3]
+num = sys.argv[3]
+desc = sys.argv[4]
 
 ok = False
 for line in gzip.open(sys.argv[1], 'rt'):
     if line.startswith("##INFO=<ID={},".format(field)):
         toks = line.rstrip("\n").split(",")
-        to_check = "Description=\"{}\"".format(desc)
-        assert toks[3].startswith(to_check), f"Expected Desciption=\"{desc}\" for {field}, got {to_check} in {toks[3]}"
+        num_to_check = "Number={}".format(num)
+        assert toks[1].startswith(num_to_check), f"Expected Desciption=\"{num}\" for {field}, got {num_to_check} in {toks[1]}"
+        desc_to_check = "Description=\"{}\"".format(desc)
+        assert toks[3].startswith(desc_to_check), f"Expected Desciption=\"{desc}\" for {field}, got {desc_to_check} in {toks[3]}"
         ok = True
         break
     # only want to look through header

--- a/tests/check-string-for-issue33.py
+++ b/tests/check-string-for-issue33.py
@@ -1,0 +1,26 @@
+"""
+Small test to ensure expected INFO fields generated
+"""
+import sys
+import gzip
+
+fpath = sys.argv[1]
+field = sys.argv[2]
+desc = sys.argv[3]
+
+ok = False
+for line in gzip.open(sys.argv[1], 'rt'):
+    if line.startswith("##INFO=<ID={},".format(field)):
+        toks = line.rstrip("\n").split(",")
+        to_check = "Description=\"{}\"".format(desc)
+        assert toks[3].startswith(to_check), f"Expected Desciption=\"{desc}\" for {field}, got {to_check} in {toks[3]}"
+        ok = True
+        break
+    # only want to look through header
+    elif line.startswith("#CHROM"):
+        break
+if not ok:
+    print(f"Expected field {field} not found in INFO", file=sys.stderr)
+    sys.exit(1)
+else:
+    sys.exit(0)

--- a/tests/make-vcf.py
+++ b/tests/make-vcf.py
@@ -27,7 +27,7 @@ print(header % 0, file=subset0_fh)
 print(header % 1, file=subset1_fh)
 
 nvar = 0
-
+str_vals = ["YES", "NO", "MAYBE"]
 for switch in [1, 2, 3, 4, 5, 1132, 1133, 1134]:
     switch = switch<<20
 
@@ -38,13 +38,14 @@ for switch in [1, 2, 3, 4, 5, 1132, 1133, 1134]:
                 for alen in range(0, 5):
                     for balt in itertools.permutations("ACGT", alen):
                         val = random.randint(0, 10000000)
+                        ac = random.randint(1, 3)
                         alt = ref[0] + "".join(balt)
-                        print(f"chr1\t{i}\t.\t{ref}\t{alt}\t1\tPASS\tval={val};nvar={nvar}", file=all_fh)
+                        print(f"chr1\t{i}\t.\t{ref}\t{alt}\t1\tPASS\tval={val};nvar={nvar};AC={ac};str={str_vals[(ac-1)]}", file=all_fh)
 
                         if nvar % mod == 0:
-                            print(f"chr1\t{i}\t.\t{ref}\t{alt}\t1\tPASS\tval0={val};nvar={nvar}", file=subset0_fh)
+                            print(f"chr1\t{i}\t.\t{ref}\t{alt}\t1\tPASS\tval0={val};nvar={nvar};AC={ac};str={str_vals[(ac-1)]}", file=subset0_fh)
                         else:
-                            print(f"chr1\t{i}\t.\t{ref}\t{alt}\t1\tPASS\tval1={val};nvar={nvar}", file=subset1_fh)
+                            print(f"chr1\t{i}\t.\t{ref}\t{alt}\t1\tPASS\tval1={val};nvar={nvar};AC={ac};str={str_vals[(ac-1)]}", file=subset1_fh)
                         nvar += 1
 
         for ref in ["ACCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",

--- a/tests/test0.hjson
+++ b/tests/test0.hjson
@@ -1,3 +1,3 @@
 [
-  {"field": "val0", "alias": "aval"}
+  {"field": "val0", "alias": "aval", "description": "TEST description field"}
 ]

--- a/tests/test0.hjson
+++ b/tests/test0.hjson
@@ -1,3 +1,4 @@
 [
-  {"field": "val0", "alias": "aval", "description": "TEST description field"}
+  {"field": "val0", "alias": "aval", "description": "TEST description field"},
+  {"field": "AC", "alias": "external_AC", "description": "Theoretical AC from another source"}
 ]

--- a/tests/test1.hjson
+++ b/tests/test1.hjson
@@ -1,3 +1,4 @@
 [
-  {"field": "val1", "alias": "aval1"}
+  {"field": "val1", "alias": "aval1"},
+  {"field": "str", "alias": "external_str"}
 ]


### PR DESCRIPTION
Partly addresses feature request # https://github.com/brentp/echtvar/issues/33
 - Is able to parse and return the correct `Number` attribute for info to update_header
 - Allows user to specify in config a `Description` to override the default
 TO DO: Actually scrape the description from the source vcf file

Built locally, got compiler warning:
```
warning: unreachable pattern
   --> src/commands/encoder_cmd.rs:226:13
    |
226 |             _ => panic!(
    |             ^
    |
    = note: `#[warn(unreachable_patterns)]` on by default
```
When run, headers are output as desired