### PR TITLE
✨  scrape descriptions on encode

### DIFF
--- a/src/commands/encoder_cmd.rs
+++ b/src/commands/encoder_cmd.rs
@@ -176,7 +176,7 @@ fn hdr_info_id2description(
         HeaderRecord::Info {key: _, values: v} => if v.contains_key("Description") { &v["Description"] } else { default },
         _ => default,
     };
-    return description.to_string();
+    return description.trim_matches('"').to_string();
 }
 
 pub fn encoder_main(vpaths: Vec<&str>, opath: &str, jpath: &str) {
@@ -247,9 +247,8 @@ pub fn encoder_main(vpaths: Vec<&str>, opath: &str, jpath: &str) {
                 tl, f.field
             ),
         };
-        let hdr_des = hdr_info_id2description(header.header_records(), &f.field, &f.description);
         if f.description == fields::default_description_string() {
-            f.description = hdr_des;
+            f.description = hdr_info_id2description(header.header_records(), &f.field, &f.description);
         };
     }
 

--- a/src/commands/encoder_cmd.rs
+++ b/src/commands/encoder_cmd.rs
@@ -1,6 +1,6 @@
 use bincode::Options;
 use echtvar_lib::{echtvar::bstrip_chr, fields, kmer16, var32, zigzag};
-use rust_htslib::bcf::header::{TagLength, TagType};
+use rust_htslib::bcf::header::{TagLength, TagType, HeaderRecord};
 use rust_htslib::bcf::record::{Buffer, Record};
 use rust_htslib::bcf::{Read as BCFRead, Reader};
 use stream_vbyte::{encode::encode, x86::Sse41};
@@ -160,6 +160,25 @@ fn is_sorted<T: std::cmp::PartialOrd>(data: &Vec<T>) -> bool {
     return true;
 }
 
+fn hdr_info_id2description(
+    mut hrecs: Vec<HeaderRecord>,
+    id: &String,
+    default: &std::string::String,
+) -> std::string::String {
+    hrecs.retain(|rec| match rec {
+        HeaderRecord::Info {key: _, values: v} => &v["ID"] == id,
+        _ => false}
+    );
+    if hrecs.len() != 1 {
+        panic!("Field {} is either not present in the header or present multiple times!", id);
+    };
+    let description = match hrecs.first().unwrap() {
+        HeaderRecord::Info {key: _, values: v} => if v.contains_key("Description") { &v["Description"] } else { default },
+        _ => default,
+    };
+    return description.to_string();
+}
+
 pub fn encoder_main(vpaths: Vec<&str>, opath: &str, jpath: &str) {
     let zpath = std::path::Path::new(opath);
     let jpath = std::path::Path::new(jpath);
@@ -228,6 +247,9 @@ pub fn encoder_main(vpaths: Vec<&str>, opath: &str, jpath: &str) {
                 tl, f.field
             ),
         };
+        println!("Old description for field {}: {}", f.field, f.description);
+        f.description = hdr_info_id2description(header.header_records(), &f.field, &f.description);
+        println!("New description for field {}: {}", f.field, f.description);
     }
 
     let zfile = std::fs::File::create(&zpath).unwrap();

--- a/src/commands/encoder_cmd.rs
+++ b/src/commands/encoder_cmd.rs
@@ -247,9 +247,10 @@ pub fn encoder_main(vpaths: Vec<&str>, opath: &str, jpath: &str) {
                 tl, f.field
             ),
         };
-        println!("Old description for field {}: {}", f.field, f.description);
-        f.description = hdr_info_id2description(header.header_records(), &f.field, &f.description);
-        println!("New description for field {}: {}", f.field, f.description);
+        let hdr_des = hdr_info_id2description(header.header_records(), &f.field, &f.description);
+        if f.description == fields::default_description_string() {
+            f.description = hdr_des;
+        };
     }
 
     let zfile = std::fs::File::create(&zpath).unwrap();

--- a/src/lib/echtvar.rs
+++ b/src/lib/echtvar.rs
@@ -177,7 +177,7 @@ impl EchtVars {
         for e in &self.fields {
             header.push_record(
                 format!(
-                    "##INFO=<ID={},Number={},Type={},Description=\"{}\">",
+                    "##INFO=<ID={},Number={},Type={},Description={}>",
                     e.alias,
                     if vec!["A", "R", "G"].iter().any(|n| n == &e.number) {
                         "1"
@@ -191,8 +191,8 @@ impl EchtVars {
                     } else {
                         "Float"
                     },
-                    if &e.description.to_string() == "added by echtvar" {
-                        format!("added by echtvar from {}", path)
+                    if &e.description.to_string() == "added by echtvar"{
+                        format!("\"added by echtvar from {}\"", path)
                     } else {
                         format!("added by echtvar {}", e.description.to_string())
                     }

--- a/src/lib/echtvar.rs
+++ b/src/lib/echtvar.rs
@@ -177,7 +177,7 @@ impl EchtVars {
         for e in &self.fields {
             header.push_record(
                 format!(
-                    "##INFO=<ID={},Number={},Type={},Description={}>",
+                    "##INFO=<ID={},Number={},Type={},Description=\"{}\">",
                     e.alias,
                     if vec!["A", "R", "G"].iter().any(|n| n == &e.number) {
                         "1"
@@ -191,8 +191,8 @@ impl EchtVars {
                     } else {
                         "Float"
                     },
-                    if &e.description.to_string() == "added by echtvar"{
-                        format!("\"added by echtvar from {}\"", path)
+                    if e.description.to_string() == fields::default_description_string() {
+                        format!("added by echtvar from {}", path)
                     } else {
                         format!("added by echtvar {}", e.description.to_string())
                     }

--- a/src/lib/fields.rs
+++ b/src/lib/fields.rs
@@ -40,7 +40,7 @@ fn default_missing_value() -> i32 {
 fn default_missing_string() -> std::string::String {
     "MISSING".to_string()
 }
-fn default_description_string() -> std::string::String {
+pub fn default_description_string() -> std::string::String {
     "added by echtvar".to_string()
 }
 fn default_multiplier() -> u32 {


### PR DESCRIPTION
Followup work to https://github.com/brentp/echtvar/pull/34.

I tried to tackle the task of INFO field description scraping requested in https://github.com/brentp/echtvar/issues/33. Found rust-htslib pretty ill-equipped for the task, but I'm way too much of a rust/c novice to delve deeply into the core of htslib. This could perhaps be done better using `bcf_hdr_get_hrec`.

In the end I made a short function to filter down the `HeaderRecord vector` using an `ID` value. Since there should only ever be one INFO header record with a particular ID, I return the description from the first of the remaining records. If it's not there I pass along the default value. On the way out I make sure to trim the `"` since the `update_header` function expects the descriptions to be unquoted.

In the `encoder_main` function I only call this function when the `field` `description` is not the default. I figure we'd want to give user priority in field naming.

As for how the check against the default is done, I couldn't really figure out how to get a default value for a field the way things were so I went ahead and made the `fields::default_description_string()` function public. I'm not sure if that's a good way of doing that so I'm open to suggestions.

Let me know if this is fine. Feel free to discard the PR if you want to go about this a different way.