### PR TITLE
non ACGT Bug fix kinda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ Cargo.lock
 ec.zip
 echtvar/
 sl.zip
-
+tests/*.vcf*
+tests/test.echtvar*
 
 # Added by cargo
 #

--- a/src/lib/echtvar.rs
+++ b/src/lib/echtvar.rs
@@ -181,7 +181,7 @@ impl EchtVars {
                 format!(
                     "##INFO=<ID={},Number={},Type={},Description=\"{}\">",
                     e.alias,
-                    if vec!["A", "R", "G"].contains(&e.number) {
+                    if vec!["A", "R", "G"].iter().any(|n| n == &e.number) {
                         "1"
                     } else {
                         &e.number

--- a/src/lib/var32.rs
+++ b/src/lib/var32.rs
@@ -21,7 +21,7 @@ pub struct Var32 {
 }
 
 const fn init_bitset() -> u128 {
-    (1 << 'A' as usize) | (1 << 'C' as usize) | (1 << 'G' as usize) | (1 << 'T' as usize)
+    (1 << 'A' as usize) | (1 << 'C' as usize) | (1 << 'G' as usize) | (1 << 'T' as usize) | (1 << '*' as usize)
 }
 
 // use a bitset to check if incoming letters are ACGT and issue warning if not.
@@ -72,12 +72,12 @@ pub const MAX_COMBINED_LEN: usize = 4;
 
 pub(crate) const LOOKUP: [u32; 128] = [
     3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
     3, 0, 3, 1, 3, 3, 3, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
     3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 ];
 
-pub(crate) const RLOOKUP: [char; 4] = ['A', 'C', 'G', 'T'];
+pub(crate) const RLOOKUP: [char; 5] = ['A', 'C', 'G', 'T', '*'];
 
 impl From<u32> for Var32 {
     #[inline]
@@ -116,7 +116,7 @@ pub fn encode(pos: u32, ref_allele: &[u8], alt_allele: &[u8], warn:&mut i32) -> 
         if !bit_test(DNA_BITS, *a as usize) && *warn < 10 {
 			*warn += 1;
             eprintln!(
-                "[warning] found non ACGT REF character '{}', encoding as 'T' for (1-based) position: {}",
+                "[warning] found non ACGT* REF character '{}', encoding as 'T' for (1-based) position: {}",
                 *a as char, pos + 1
             );
         }
@@ -128,7 +128,7 @@ pub fn encode(pos: u32, ref_allele: &[u8], alt_allele: &[u8], warn:&mut i32) -> 
         if !bit_test(DNA_BITS, *a as usize) && *warn < 10 {
 			*warn += 1;
             eprintln!(
-                "[warning] found non ACGT ALT character '{}', encoding as 'T' for (1-based) position: {}",
+                "[warning] found non ACGT* ALT character '{}', encoding as 'T' for (1-based) position: {}",
                 *a as char, pos + 1
             );
         }


### PR DESCRIPTION
Going on the premise that GATK's outputs are wildly popular and that in their format, `*` is a valid alt possibility, even if in practice you would not use it:

- allow * as acceptable value
- However, other characters would still cause the bug to reappear, like if there was an `N`
Separately, I :revert vec as change in main as it causes compile fail. Also a small update to git ignore to avoid test files

Fixes #36 