### PR TITLE
Feature/fix issue 36

### DIFF
--- a/src/commands/annotate_cmd.rs
+++ b/src/commands/annotate_cmd.rs
@@ -125,7 +125,20 @@ pub fn annotate_main(
             );
         }
         n += 1;
+        // First check if the variant is *, skip those
+        if String::from_utf8_lossy(record.alleles()[1]) == "*" {
+            let rid = record.rid().unwrap();
+            let chrom = std::str::from_utf8(oheader_view.rid2name(rid).unwrap()).unwrap();
+            eprintln!(
+                "contig {} pos {} alt has * value, skipping annotation, outputting entry as-is",
+                &chrom,
+                record.pos() + 1
+            );
+            ovcf.write(&record).expect("failed to write record");
+            continue;
+        }
         // this updates evalues and fills expr values
+
         for (i, e) in echts.iter_mut().enumerate() {
             e.update_expr_values(&mut record, &mut expr_values[i]);
         }

--- a/src/commands/annotate_cmd.rs
+++ b/src/commands/annotate_cmd.rs
@@ -138,6 +138,7 @@ pub fn annotate_main(
                     record.pos() + 1
                 );
             }
+            if skip_warn == 9 { eprintln!("not reporting further warnings") }
             skip_warn += 1;
             ovcf.write(&record).expect("failed to write record");
             continue;

--- a/src/commands/annotate_cmd.rs
+++ b/src/commands/annotate_cmd.rs
@@ -137,8 +137,8 @@ pub fn annotate_main(
                     &chrom,
                     record.pos() + 1
                 );
+                if skip_warn == 9 { eprintln!("not reporting further warnings") }
             }
-            if skip_warn == 9 { eprintln!("not reporting further warnings") }
             skip_warn += 1;
             ovcf.write(&record).expect("failed to write record");
             continue;

--- a/src/commands/annotate_cmd.rs
+++ b/src/commands/annotate_cmd.rs
@@ -100,6 +100,7 @@ pub fn annotate_main(
     let mut n = 0u64;
     let mut n_written = 0u64;
     let mut modu = 10000u64;
+    let mut skip_warn = 0;
 
     for r in vcf.records() {
         let mut record = r.expect("error reading record");
@@ -126,14 +127,18 @@ pub fn annotate_main(
         }
         n += 1;
         // First check if the variant is *, skip those
-        if String::from_utf8_lossy(record.alleles()[1]) == "*" {
+        if record.alleles()[1][0] == b'*' {
             let rid = record.rid().unwrap();
             let chrom = std::str::from_utf8(oheader_view.rid2name(rid).unwrap()).unwrap();
-            eprintln!(
-                "contig {} pos {} alt has * value, skipping annotation, outputting entry as-is",
-                &chrom,
-                record.pos() + 1
-            );
+            // Only warn up to 10 times, just keep count in general
+            if skip_warn < 10 {
+                eprintln!(
+                    "contig {} pos {} alt has * value, skipping annotation, outputting entry as-is",
+                    &chrom,
+                    record.pos() + 1
+                );
+            }
+            skip_warn += 1;
             ovcf.write(&record).expect("failed to write record");
             continue;
         }
@@ -192,6 +197,10 @@ pub fn annotate_main(
         n,
         1000 * (n as u128) / mili,
         n_written,
+    );
+    eprintln!(
+        "Skipped {} variants with * alt.",
+        skip_warn,
     );
 
     /*

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,6 +1,4 @@
 anno.vcf.gz
-generated-all.vcf
-generated-exclude.vcf
-test.echtvar
-test.echtvar.before
+generated-*
+test.echtvar*
 sl.zip


### PR DESCRIPTION
My colleague @dmiller15 had a much simpler suggestion to simply skip `*` entries as a start in the annotator tool. It'd likely tidy up our current concerns...expanding to skip all non ACGT alleles (like `N` or `ACN`) could be tackled, but not sure it needs to immediately.