### PR TITLE
ARM support: use Scalar stream-vbyte on non-x86, SIMD on x86_64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 rust-htslib = { version = "0.38.2", features = ["libdeflate", "static"] }
 #bitpacking = "0.8.4"
-stream-vbyte = { version = "0.4.1", features = ["x86_ssse3", "x86_sse41"] }
+stream-vbyte = "0.4.1"
 clap = { version = "~2.27.0", features = ["suggestions"] }
 c2rust-bitfields = "0.3.0"
 libc = "*"
@@ -33,6 +33,10 @@ bincode = { version = "1.3.3" }
 json5 = "0.4.1"
 
 ieee754 = "0.2"
+
+# x86 SIMD (Ssse3 decode, Sse41 encode) enabled only on x86_64; other arches use Scalar
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+stream-vbyte = { version = "0.4.1", features = ["x86_ssse3", "x86_sse41"] }
 
 [profile.release]
 lto = "fat"

--- a/src/commands/annotate_cmd.rs
+++ b/src/commands/annotate_cmd.rs
@@ -230,7 +230,7 @@ pub fn annotate_main(
     let mut nums: Vec<u32> = Vec::new();
     nums.resize(n, 0);
 
-    let n_d = decode::<Ssse3>(&comr, n, &mut nums);
+    let n_d = decode::<Scalar>(&comr, n, &mut nums);
     eprintln!("{} {} {:?}", n_d, iz.size(), &nums[..1000]);
     */
 

--- a/src/commands/annotate_cmd.rs
+++ b/src/commands/annotate_cmd.rs
@@ -230,7 +230,7 @@ pub fn annotate_main(
     let mut nums: Vec<u32> = Vec::new();
     nums.resize(n, 0);
 
-    let n_d = decode::<Scalar>(&comr, n, &mut nums);
+    let n_d = decode::<Ssse3>(&comr, n, &mut nums);
     eprintln!("{} {} {:?}", n_d, iz.size(), &nums[..1000]);
     */
 

--- a/src/commands/encoder_cmd.rs
+++ b/src/commands/encoder_cmd.rs
@@ -3,12 +3,11 @@ use echtvar_lib::{echtvar::bstrip_chr, fields, kmer16, var32, zigzag};
 use rust_htslib::bcf::header::{HeaderRecord, TagLength, TagType};
 use rust_htslib::bcf::record::{Buffer, Record};
 use rust_htslib::bcf::{Read as BCFRead, Reader};
+use stream_vbyte::encode::encode;
 #[cfg(target_arch = "x86_64")]
 use stream_vbyte::x86::Sse41;
-#[cfg(target_arch = "x86_64")]
-use stream_vbyte::encode::encode;
 #[cfg(not(target_arch = "x86_64"))]
-use stream_vbyte::{encode::encode, scalar::Scalar};
+use stream_vbyte::scalar::Scalar;
 
 #[cfg(target_arch = "x86_64")]
 type StreamVbyteEncoder = Sse41;

--- a/src/commands/encoder_cmd.rs
+++ b/src/commands/encoder_cmd.rs
@@ -3,7 +3,17 @@ use echtvar_lib::{echtvar::bstrip_chr, fields, kmer16, var32, zigzag};
 use rust_htslib::bcf::header::{HeaderRecord, TagLength, TagType};
 use rust_htslib::bcf::record::{Buffer, Record};
 use rust_htslib::bcf::{Read as BCFRead, Reader};
-use stream_vbyte::{encode::encode, x86::Sse41};
+#[cfg(target_arch = "x86_64")]
+use stream_vbyte::x86::Sse41;
+#[cfg(target_arch = "x86_64")]
+use stream_vbyte::encode::encode;
+#[cfg(not(target_arch = "x86_64"))]
+use stream_vbyte::{encode::encode, scalar::Scalar};
+
+#[cfg(target_arch = "x86_64")]
+type StreamVbyteEncoder = Sse41;
+#[cfg(not(target_arch = "x86_64"))]
+type StreamVbyteEncoder = Scalar;
 
 use std::borrow::{Borrow, BorrowMut};
 use std::collections::HashMap;
@@ -133,7 +143,7 @@ fn write_bits(
         }
     }
 
-    let encoded_len = encode::<Sse41>(values, compressed);
+    let encoded_len = encode::<StreamVbyteEncoder>(values, compressed);
     zipf.write_all(&compressed[..encoded_len]).ok();
 }
 

--- a/src/lib/echtvar.rs
+++ b/src/lib/echtvar.rs
@@ -10,7 +10,17 @@ use std::{fs, io, str};
 use byteorder::{LittleEndian, ReadBytesExt};
 use std::io::BufReader;
 
-use stream_vbyte::{decode::decode, x86::Ssse3};
+#[cfg(target_arch = "x86_64")]
+use stream_vbyte::x86::Ssse3;
+#[cfg(target_arch = "x86_64")]
+use stream_vbyte::decode::decode;
+#[cfg(not(target_arch = "x86_64"))]
+use stream_vbyte::{decode::decode, scalar::Scalar};
+
+#[cfg(target_arch = "x86_64")]
+type StreamVbyteDecoder = Ssse3;
+#[cfg(not(target_arch = "x86_64"))]
+type StreamVbyteDecoder = Scalar;
 
 use ieee754::Ieee754;
 
@@ -254,7 +264,7 @@ impl EchtVars {
                     self.values[fi.values_i].resize(n, 0x0);
                     // TODO: use skip to first position.
                     let bytes_decoded =
-                        decode::<Ssse3>(&self.buffer, n, &mut self.values[fi.values_i]);
+                        decode::<StreamVbyteDecoder>(&self.buffer, n, &mut self.values[fi.values_i]);
 
                     if bytes_decoded != self.buffer.len() {
                         return Err(std::io::Error::new(
@@ -281,7 +291,7 @@ impl EchtVars {
             iz.read_exact(&mut self.buffer)?;
 
             self.var32s.resize(n, 0x0);
-            let bytes_decoded = decode::<Ssse3>(&self.buffer, n, &mut self.var32s);
+            let bytes_decoded = decode::<StreamVbyteDecoder>(&self.buffer, n, &mut self.var32s);
             // cumsum https://users.rust-lang.org/t/inplace-cumulative-sum-using-iterator/56532/3
             self.var32s.iter_mut().fold(0, |acc, x| {
                 *x += acc;

--- a/src/lib/echtvar.rs
+++ b/src/lib/echtvar.rs
@@ -10,12 +10,11 @@ use std::{fs, io, str};
 use byteorder::{LittleEndian, ReadBytesExt};
 use std::io::BufReader;
 
+use stream_vbyte::decode::decode;
 #[cfg(target_arch = "x86_64")]
 use stream_vbyte::x86::Ssse3;
-#[cfg(target_arch = "x86_64")]
-use stream_vbyte::decode::decode;
 #[cfg(not(target_arch = "x86_64"))]
-use stream_vbyte::{decode::decode, scalar::Scalar};
+use stream_vbyte::scalar::Scalar;
 
 #[cfg(target_arch = "x86_64")]
 type StreamVbyteDecoder = Ssse3;


### PR DESCRIPTION
- Remove x86-only stream-vbyte features from default deps for macOS ARM
- Gate x86 SIMD (Ssse3 decode, Sse41 encode) on target_arch = x86_64
- Fix Cargo.toml: move target-specific deps to end so other deps apply on all targets