### PR TITLE
Update rust-htslib to fix compilation on aarch64 Linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 
 [dependencies]
-rust-htslib = { version = "0.38.2", features = ["libdeflate", "static"] }
+rust-htslib = { version = "0.39.3", features = ["libdeflate", "static"] }
 #bitpacking = "0.8.4"
 stream-vbyte = "0.4.1"
 clap = { version = "~2.27.0", features = ["suggestions"] }


### PR DESCRIPTION
Updates `rust-htslib` to apply this fix: https://github.com/rust-bio/rust-htslib/releases/tag/rust-htslib-v0.39.3

Otherwise, compilation fails with many instances of:

```text
error[E0308]: mismatched types
   --> /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rust-htslib-0.38.2/src/bam/record.rs:152:16
    |
152 |             s: sam_copy.as_ptr() as *mut i8,
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `*mut u8`, found `*mut i8`
    |
    = note: expected raw pointer `*mut u8`
               found raw pointer `*mut i8`
```